### PR TITLE
Tidy up the test scenarios

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   roles:
     - role: duplicity_backup
-  environment: # used by templates/gpg.sh.j2
+  environment:  # used by templates/gpg.sh.j2
     GPG_NAME: "root"
     GPG_EMAIL: "root@root.com"
     PASSPHRASE: test_passphrase

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,11 +5,6 @@ dependency:
     role-file: meta/requirements.yml
 driver:
   name: docker
-lint: |
-  set -e
-  yamllint .
-  flake8 .
-  ansible-lint .
 platforms:
   - name: debian_buster
     ansible_groups:
@@ -24,6 +19,7 @@ provisioner:
       all:
         ansible_python_interpreter: /usr/bin/python3
         ansible_user: root
+        duplicity_basepath: /root
         duplicity_backup_create_gpg_keypair: true
   env:
     DPBX_ACCESS_TOKEN: test_token

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -51,12 +51,12 @@ def test_gpg_permissions(host, gpg_dir):
     assert gpg_dir.mode == 0o700
 
 
-# Test if duplicity directories and files exist if their permissions are
+# Test if duplicity directories and files exist and if their permissions are
 # correct
 @pytest.mark.parametrize("duplicity_dirs", [
-    ("/.duplicity"),
-    ("/.duplicity/.backup.sh"),
-    ("/.duplicity/.restore.sh"),
+    ("/root/.duplicity"),
+    ("/root/.duplicity/.backup.sh"),
+    ("/root/.duplicity/.restore.sh"),
     ("/var/log/duplicity")
 ])
 
@@ -67,7 +67,7 @@ def test_duplicity_permissions(host, duplicity_dirs):
     assert duplicity_dir.group == "root"
     assert duplicity_dir.mode == 0o700
 
-    env_var_conf = host.file("/.duplicity/.env_variables.conf")
+    env_var_conf = host.file("/root/.duplicity/.env_variables.conf")
     assert env_var_conf.exists
     assert env_var_conf.user == "root"
     assert env_var_conf.group == "root"
@@ -106,5 +106,5 @@ def test_log_rotation(host, line):
 ])
 
 def test_env_var_values(host, line):
-    env_var_conf = host.file("/.duplicity/.env_variables.conf")
+    env_var_conf = host.file("/root/.duplicity/.env_variables.conf")
     assert env_var_conf.contains(line)

--- a/molecule/restore/molecule.yml
+++ b/molecule/restore/molecule.yml
@@ -5,11 +5,6 @@ dependency:
     role-file: meta/requirements.yml
 driver:
   name: docker
-lint: |
-  set -e
-  yamllint .
-  flake8 .
-  ansible-lint .
 platforms:
   - name: debian_buster
     ansible_groups:
@@ -26,6 +21,11 @@ provisioner:
         ansible_user: root
         duplicity_basepath: /root
         gpg_key_path: "{{ role_path }}/files/gnupg"
+  env:
+    DPBX_ACCESS_TOKEN: test_token
+    DPBX_APP_KEY: test_key
+    DPBX_APP_SECRET: test_secret
+    PASSPHRASE: test_passphrase
 verifier:
   name: testinfra
 ...

--- a/molecule/restore/tests/test_restore.py
+++ b/molecule/restore/tests/test_restore.py
@@ -4,7 +4,6 @@ import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
-
 # Test if apt installed the required packages
 @pytest.mark.parametrize("package", [
     ("python3-venv"),
@@ -13,7 +12,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     ("librsync-dev"),
     ("haveged"),
 ])
-
 def test_apt_prerequisites(host, package):
     pkg = host.package(package)
     assert pkg.is_installed
@@ -54,9 +52,9 @@ def test_gpg_permissions(host, gpg_dir):
 # Test if duplicity directories and files exist and if their permissions are
 # correct
 @pytest.mark.parametrize("duplicity_dirs", [
-    ("/.duplicity"),
-    ("/.duplicity/.backup.sh"),
-    ("/.duplicity/.restore.sh"),
+    ("/root/.duplicity"),
+    ("/root/.duplicity/.backup.sh"),
+    ("/root/.duplicity/.restore.sh"),
     ("/var/log/duplicity")
 ])
 
@@ -67,13 +65,14 @@ def test_duplicity_permissions(host, duplicity_dirs):
     assert duplicity_dir.group == "root"
     assert duplicity_dir.mode == 0o700
 
-    env_var_conf = host.file("/.duplicity/.env_variables.conf")
+    env_var_conf = host.file("/root/.duplicity/.env_variables.conf")
     assert env_var_conf.exists
     assert env_var_conf.user == "root"
     assert env_var_conf.group == "root"
     assert env_var_conf.mode == 0o600
 
 
+# Test if log rotation works
 @pytest.mark.parametrize("line", [
     ("/var/log/duplicity/duplicity_backup.log"),
     ("rotate 30"),
@@ -95,8 +94,7 @@ def test_log_rotation(host, line):
     assert cmd.succeeded == True
 
 
-# Test if .env_variables.conf includes correct values
-
+# Test if .env_variables.conf includes correct lines
 @pytest.mark.parametrize("line", [
     ('export DPBX_ACCESS_TOKEN="test_token"'),
     ('export DPBX_APP_KEY="test_key"'),
@@ -106,5 +104,5 @@ def test_log_rotation(host, line):
 ])
 
 def test_env_var_values(host, line):
-    env_var_conf = host.file("/.duplicity/.env_variables.conf")
+    env_var_conf = host.file("/root/.duplicity/.env_variables.conf")
     assert env_var_conf.contains(line)

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -7,7 +7,9 @@
     - duplicity_backup_create_gpg_keypair is defined
     - duplicity_backup_create_gpg_keypair|bool
   no_log: true  # includes secrets
-  tags: duplicity_backup_create_gpg_keypair
+  tags:
+    - duplicity_backup_create_gpg_keypair
+    - molecule-idempotence-notest
 
 - name: Deploy existing GPG keypair  # required for restoring a backup
   block:


### PR DESCRIPTION
* Adjust the default and restoration test scenarios to pass molecule
  test
* Don't test the idempotency of GPG keypair creation since the default
  scenario always creates a new keypair because of the configured extra
  variable called duplicity_backup_create_gpg_keypair
* Rename restoration tests
* Define environment variables in the restoration tests
* Define duplicity_basepath of the default test scenario to unify the
  configuration of the default and restoration test scenarios. All files
  are now deployed to the same paths in both scenarios.
* Fix the paths that the restoration tests test against